### PR TITLE
✨ Feat : Comment - 생성 기능, 조회 기능 구현

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -205,12 +205,6 @@ set -- \
         org.gradle.wrapper.GradleWrapperMain \
         "$@"
 
-# Stop when "xargs" is not available.
-if ! command -v xargs >/dev/null 2>&1
-then
-    die "xargs is not available"
-fi
-
 # Use "xargs" to parse quoted args.
 #
 # With -n1 it outputs one arg per line, with the quotes and backslashes removed.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@
 @rem limitations under the License.
 @rem
 
-@if "%DEBUG%"=="" @echo off
+@if "%DEBUG%" == "" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +25,7 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%"=="" set DIRNAME=.
+if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if %ERRORLEVEL% equ 0 goto execute
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -75,15 +75,13 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if %ERRORLEVEL% equ 0 goto mainEnd
+if "%ERRORLEVEL%"=="0" goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-set EXIT_CODE=%ERRORLEVEL%
-if %EXIT_CODE% equ 0 set EXIT_CODE=1
-if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
-exit /b %EXIT_CODE%
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/src/main/java/com/team1/TBBCloneCoding/comment/controller/CommentController.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/controller/CommentController.java
@@ -1,15 +1,13 @@
 package com.team1.TBBCloneCoding.comment.controller;
 
 import com.team1.TBBCloneCoding.comment.dto.CommentCreateRequestDto;
-import com.team1.TBBCloneCoding.comment.dto.CommentResponseDto;
 import com.team1.TBBCloneCoding.comment.service.CommentService;
 import com.team1.TBBCloneCoding.common.dto.ResponseDto;
 import com.team1.TBBCloneCoding.member.entity.Member;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 @RequestMapping("/api/tumblebug")
@@ -20,24 +18,20 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/project/{projectId}/comment")
-    public ResponseDto createComment(Member member, @PathVariable Long projectId, @RequestBody CommentCreateRequestDto commentCreateRequestDto) {
+    public ResponseEntity<ResponseDto> createComment(Member member, @PathVariable Long projectId, @RequestBody CommentCreateRequestDto commentCreateRequestDto) {
 
-        Long memberId = member.getMemberId();
+        ResponseDto responseDto = commentService.createComment(member, projectId, commentCreateRequestDto);
 
-        commentService.createComment(memberId, projectId, commentCreateRequestDto);
-
-        return new ResponseDto("성공","댓글을 작성하였습니다",null);
+        return new ResponseEntity(responseDto, HttpStatus.OK) ;
     }
 
 
     @GetMapping("/project/{projectId}/comment")
-    public ResponseDto getAllComment(Member member, @PathVariable Long projectId) {
+    public ResponseEntity<ResponseDto> getAllComment(Member member, @PathVariable Long projectId) {
 
-        Long memberId = member.getMemberId();
+        ResponseDto responseDto = commentService.getAllComment(member, projectId);
 
-        List<CommentResponseDto> commentResponseDtoList = commentService.getAllComment(projectId, memberId);
-
-        return new ResponseDto("성공", "댓글 조회에 성공하였습니다", commentResponseDtoList);
+        return new ResponseEntity(responseDto, HttpStatus.OK);
 
     }
 

--- a/src/main/java/com/team1/TBBCloneCoding/comment/controller/CommentController.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/controller/CommentController.java
@@ -1,0 +1,44 @@
+package com.team1.TBBCloneCoding.comment.controller;
+
+import com.team1.TBBCloneCoding.comment.dto.CommentCreateRequestDto;
+import com.team1.TBBCloneCoding.comment.dto.CommentResponseDto;
+import com.team1.TBBCloneCoding.comment.service.CommentService;
+import com.team1.TBBCloneCoding.common.dto.ResponseDto;
+import com.team1.TBBCloneCoding.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RequestMapping("/api/tumblebug")
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/project/{projectId}/comment")
+    public ResponseDto createComment(Member member, @PathVariable Long projectId, @RequestBody CommentCreateRequestDto commentCreateRequestDto) {
+
+        Long memberId = member.getMemberId();
+
+        commentService.createComment(memberId, projectId, commentCreateRequestDto);
+
+        return new ResponseDto("성공","댓글을 작성하였습니다",null);
+    }
+
+
+    @GetMapping("/project/{projectId}/comment")
+    public ResponseDto getAllComment(Member member, @PathVariable Long projectId) {
+
+        Long memberId = member.getMemberId();
+
+        List<CommentResponseDto> commentResponseDtoList = commentService.getAllComment(projectId, memberId);
+
+        return new ResponseDto("성공", "댓글 조회에 성공하였습니다", commentResponseDtoList);
+
+    }
+
+}

--- a/src/main/java/com/team1/TBBCloneCoding/comment/dto/CommentCreateRequestDto.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/dto/CommentCreateRequestDto.java
@@ -1,0 +1,12 @@
+package com.team1.TBBCloneCoding.comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequestDto {
+
+    private String contents;
+
+}

--- a/src/main/java/com/team1/TBBCloneCoding/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/dto/CommentResponseDto.java
@@ -1,0 +1,19 @@
+package com.team1.TBBCloneCoding.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class CommentResponseDto {
+
+    private Long commentId;
+    private String contents;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private Boolean commentIsMine;
+
+}

--- a/src/main/java/com/team1/TBBCloneCoding/comment/entity/Comment.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/entity/Comment.java
@@ -1,16 +1,19 @@
 package com.team1.TBBCloneCoding.comment.entity;
 
+import com.team1.TBBCloneCoding.common.entity.TimeStamp;
+import com.team1.TBBCloneCoding.member.entity.Member;
 import com.team1.TBBCloneCoding.project.entity.Project;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Comment {
+public class Comment extends TimeStamp {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,13 +22,25 @@ public class Comment {
     @Column(nullable = false)
     private String contents;
 
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+
     @ManyToOne
     @JoinColumn(name = "Project_Id", nullable = false)
     private Project project;
 
+    @ManyToOne
+    @JoinColumn(name = "Member_Id", nullable = false)
+    private Member member;
+
+
     @Builder
-    public Comment(String contents, Project project) {
+    public Comment(String contents, Project project, Member member) {
         this.contents = contents;
         this.project = project;
+        this.member = member;
     }
 }

--- a/src/main/java/com/team1/TBBCloneCoding/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/mapper/CommentMapper.java
@@ -1,0 +1,28 @@
+package com.team1.TBBCloneCoding.comment.mapper;
+
+import com.team1.TBBCloneCoding.comment.dto.CommentCreateRequestDto;
+import com.team1.TBBCloneCoding.comment.dto.CommentResponseDto;
+import com.team1.TBBCloneCoding.comment.entity.Comment;
+import com.team1.TBBCloneCoding.member.entity.Member;
+import com.team1.TBBCloneCoding.project.entity.Project;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentMapper {
+
+    public Comment toComment(Member member, CommentCreateRequestDto commentCreateRequestDto, Project project){
+        return new Comment(commentCreateRequestDto.getContents(), project, member);
+    }
+
+    public CommentResponseDto toResponseDto(Comment comment, Boolean commentIsMine){
+        return CommentResponseDto.builder()
+                .commentId(comment.getCommentId())
+                .contents(comment.getContents())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .commentIsMine(commentIsMine)
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/team1/TBBCloneCoding/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/repository/CommentRepository.java
@@ -1,7 +1,13 @@
 package com.team1.TBBCloneCoding.comment.repository;
 
 import com.team1.TBBCloneCoding.comment.entity.Comment;
+import com.team1.TBBCloneCoding.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByOrderByLastModifiedAtDesc();
+
 }

--- a/src/main/java/com/team1/TBBCloneCoding/comment/service/CommentService.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/service/CommentService.java
@@ -1,6 +1,5 @@
 package com.team1.TBBCloneCoding.comment.service;
 
-import com.team1.TBBCloneCoding.comment.controller.CommentController;
 import com.team1.TBBCloneCoding.comment.dto.CommentCreateRequestDto;
 import com.team1.TBBCloneCoding.comment.dto.CommentResponseDto;
 import com.team1.TBBCloneCoding.comment.entity.Comment;
@@ -31,9 +30,11 @@ public class CommentService {
     private final CommentMapper commentMapper;
 
     @Transactional
-    public void createComment(Long memberId, Long projectId, CommentCreateRequestDto commentCreateRequestDto){
+    public ResponseDto createComment(Member member, Long projectId, CommentCreateRequestDto commentCreateRequestDto){
 
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Long memberId = member.getMemberId();
+
+        Member memberForCreateComment = memberRepository.findById(memberId).orElseThrow(
                 () -> new NullPointerException()
         );
 
@@ -41,14 +42,18 @@ public class CommentService {
                 () -> new NullPointerException()
         );
 
-        Comment comment = commentMapper.toComment(member, commentCreateRequestDto, project);
+        Comment comment = commentMapper.toComment(memberForCreateComment, commentCreateRequestDto, project);
 
         commentRepository.save(comment);
+
+        return new ResponseDto("success", "댓글을 작성하였습니다", null);
 
     }
 
     @Transactional(readOnly = true)
-    public List<CommentResponseDto> getAllComment(Long projectId, Long memberId) {
+    public ResponseDto getAllComment(Member member, Long projectId) {
+
+        Long memberId = member.getMemberId();
 
         Boolean commentIsMine = false;
 
@@ -64,7 +69,7 @@ public class CommentService {
             allCommentResponseDto.add(commentMapper.toResponseDto(comment,commentIsMine));
         }
 
-        return allCommentResponseDto;
+        return new ResponseDto("success","댓글을 조회하였습니다", allCommentResponseDto);
 
     }
 }

--- a/src/main/java/com/team1/TBBCloneCoding/comment/service/CommentService.java
+++ b/src/main/java/com/team1/TBBCloneCoding/comment/service/CommentService.java
@@ -1,0 +1,70 @@
+package com.team1.TBBCloneCoding.comment.service;
+
+import com.team1.TBBCloneCoding.comment.controller.CommentController;
+import com.team1.TBBCloneCoding.comment.dto.CommentCreateRequestDto;
+import com.team1.TBBCloneCoding.comment.dto.CommentResponseDto;
+import com.team1.TBBCloneCoding.comment.entity.Comment;
+import com.team1.TBBCloneCoding.comment.mapper.CommentMapper;
+import com.team1.TBBCloneCoding.comment.repository.CommentRepository;
+import com.team1.TBBCloneCoding.common.dto.ResponseDto;
+import com.team1.TBBCloneCoding.member.entity.Member;
+import com.team1.TBBCloneCoding.member.repository.MemberRepository;
+import com.team1.TBBCloneCoding.project.entity.Project;
+import com.team1.TBBCloneCoding.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final ProjectRepository projectRepository;
+
+    private final CommentMapper commentMapper;
+
+    @Transactional
+    public void createComment(Long memberId, Long projectId, CommentCreateRequestDto commentCreateRequestDto){
+
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new NullPointerException()
+        );
+
+        Project project = projectRepository.findById(projectId).orElseThrow(
+                () -> new NullPointerException()
+        );
+
+        Comment comment = commentMapper.toComment(member, commentCreateRequestDto, project);
+
+        commentRepository.save(comment);
+
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getAllComment(Long projectId, Long memberId) {
+
+        Boolean commentIsMine = false;
+
+        List<CommentResponseDto> allCommentResponseDto = new ArrayList<>();
+
+        List<Comment> comments = commentRepository.findAllByOrderByLastModifiedAtDesc();
+
+        for(Comment comment : comments) {
+
+            if(comment.getMember().getMemberId().equals(memberId)){
+                commentIsMine = true;
+            }
+            allCommentResponseDto.add(commentMapper.toResponseDto(comment,commentIsMine));
+        }
+
+        return allCommentResponseDto;
+
+    }
+}


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Comment 생성 및 조회 기능 구현 하였습니다.


## 작업사항

**[코멘트 생성 기능 관련]**
- CommentCreateRequestDto 작성
- CommentController - PostMapping 로직 작성
- CommentService - createComment 로직 작성
- CommentMapper - toComment 로직 작성


**[코멘트 조회 기능 관련]**
- CommentController - GetMapping 로직 작성
- CommentService - getAllComment 로직 작성
- CommentRepository - 코멘트 변경 순으로 불러오는 메서드 선언부 추가
- CommentMapper - toResponseDto 메서드 추가
- CommentResponseDto 작성


## 변경로직
- Comment 조회 시, 변경순으로 불러오기 위해 TimeStamp 필드 추가하였습니다
- #5 브랜치에서 Member 필드 추가한 내용이 이번 작업에도 반영되었습니다

## 참고사항
- 로그인 시, UserDetailsImpl에서 member 객체를 받는다 가정하여 Controller단에서 member 를 인자로 받는 것으로 작성하였습니다
- 두 가지 기능이 한번에 작성되었는데, 다음부터는 한 가지 기능 단위로 작성하도록 할게요 ^^;;
- 추가로, 현재 gradlew와  gradlew.bat 파일이 함께 올라왔는데 이 부분 PR해도 괜찮은 건지 궁금합니다.!


## PR 수정사항
[생성, 조회 기능 모두 아래 변경 사항 적용]
1. Controller 에서 memberId 가 아닌 member 객체를 전달(to Service)
2. Service 단에서 member.getMemberId() 수행
3. Controller에서 return할때 ResponseDto 가 아닌 ResponseEntity를 반환
4. 위 변경사항(3번) 에 따라 Service 단의 return타입을 ResponseDto 로 변경

close #3 
